### PR TITLE
Fixing Issue #1

### DIFF
--- a/stub_collections.js
+++ b/stub_collections.js
@@ -5,6 +5,7 @@ import { sinon } from 'meteor/practicalmeteor:sinon';
 const StubCollections = (() => {
   const _public = {};
   const _private = {};
+  const sandbox = sinon.sandbox.create();
 
   _public.add = (collections) => {
     _private.collections.push(...collections);
@@ -28,7 +29,7 @@ const StubCollections = (() => {
   };
 
   _public.restore = () => {
-    _.each(_private.pairs, _private.restorePair);
+    sandbox.restore();
     _private.pairs = {};
   };
 
@@ -38,17 +39,13 @@ const StubCollections = (() => {
 
   _private.stubPair = (pair) => {
     _private.symbols.forEach((symbol) => {
-      sinon.stub(
-        pair.collection,
-        symbol,
-        _.bind(pair.localCollection[symbol], pair.localCollection)
-      );
-    });
-  };
-
-  _private.restorePair = (pair) => {
-    _private.symbols.forEach((symbol) => {
-      pair.collection[symbol].restore();
+      if (_.isFunction(pair.localCollection[symbol])) {
+        sandbox.stub(
+          pair.collection,
+          symbol,
+          _.bind(pair.localCollection[symbol], pair.localCollection)
+        );
+      }
     });
   };
 

--- a/stub_collections.tests.js
+++ b/stub_collections.tests.js
@@ -48,3 +48,24 @@ describe('StubCollections', function () {
     expect(widgets.find().count()).to.equal(1);
   });
 });
+
+const Something = new Mongo.Collection('something');
+describe('Issue #1: Uses sandbox', function() {
+  before(function() {
+    StubCollections.stub(Something);
+  });
+
+  after(function() {
+    StubCollections.restore();
+  });
+
+  it('should pass', function() {
+    expect(true).to.equal(true);
+  });
+
+  it('should pass with exception', function(){
+    expect(function() {
+      method_does_not_exist();
+    }).to.throw(Error);
+  });
+});


### PR DESCRIPTION
There is two errors on Issue #1.
- Sometimes after an error, the stub-collections fail to unregister certain stubs with sinon, causing the test runner to fail forever, since it is not able to stub new collections, nor clean old ones. I am not really sure if this fixes on every case, but I think the lifecycle of the sandbox ends up been cleaned when the tests run again, while the sinon.stub stays there for some reason.

- The _private.stubPair() tries to _.bind things that for some reason are not a function, that was the _.bind error I had. So I only bind on functions now. 

Again, I am not 100% sure of this correction, but so far it is working for me. I will be adding more tests to my meteor project and use this package more. 