### PR TITLE
Preserve simple schema

### DIFF
--- a/package.js
+++ b/package.js
@@ -23,6 +23,7 @@ Package.onUse(function onUse(api) {
 
 Package.onTest(function onTest(api) {
   api.use('hwillson:stub-collections');
+  api.use('aldeed:collection2@2.10.0');
   api.use(['ecmascript', 'mongo', 'practicalmeteor:chai']);
   api.mainModule('stub_collections.tests.js');
 });

--- a/stub_collections.js
+++ b/stub_collections.js
@@ -43,14 +43,12 @@ const StubCollections = (() => {
 
   privateApi.stubPair = (pair) => {
     privateApi.symbols.forEach((symbol) => {
-      if (_.isFunction(pair.localCollection[symbol])) {
-        if (symbol != 'simpleSchema') {
-          privateApi.sandbox.stub(
-            pair.collection,
-            symbol,
-            _.bind(pair.localCollection[symbol], pair.localCollection)
-          );
-        }
+      if (_.isFunction(pair.localCollection[symbol]) && symbol != 'simpleSchema') {
+        privateApi.sandbox.stub(
+          pair.collection,
+          symbol,
+          _.bind(pair.localCollection[symbol], pair.localCollection)
+        );
       }
     });
   };

--- a/stub_collections.js
+++ b/stub_collections.js
@@ -44,11 +44,13 @@ const StubCollections = (() => {
   privateApi.stubPair = (pair) => {
     privateApi.symbols.forEach((symbol) => {
       if (_.isFunction(pair.localCollection[symbol])) {
-        privateApi.sandbox.stub(
-          pair.collection,
-          symbol,
-          _.bind(pair.localCollection[symbol], pair.localCollection)
-        );
+        if (symbol != 'simpleSchema') {
+          privateApi.sandbox.stub(
+            pair.collection,
+            symbol,
+            _.bind(pair.localCollection[symbol], pair.localCollection)
+          );
+        }
       }
     });
   };

--- a/stub_collections.tests.js
+++ b/stub_collections.tests.js
@@ -21,7 +21,7 @@ if (Meteor.isServer) {
   Meteor.subscribe('widgets');
 }
 
-describe.only('StubCollections', function () {
+describe('StubCollections', function () {
   it('should stub added/registered collections', function () {
     expect(widgets.find().count()).to.equal(1);
 
@@ -51,7 +51,7 @@ describe.only('StubCollections', function () {
     expect(widgets.find().count()).to.equal(1);
   });
 
-  it.only('should stub the schema of a collection', function () {
+  it('should stub the schema of a collection', function () {
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
     StubCollections.stub([widgets]);
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');

--- a/stub_collections.tests.js
+++ b/stub_collections.tests.js
@@ -4,10 +4,13 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { expect } from 'meteor/practicalmeteor:chai';
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 
 import StubCollections from './stub_collections.js';
 
 const widgets = new Mongo.Collection('widgets');
+const schema = { schemaKey: { type: String, optional: true }};
+widgets.attachSchema(new SimpleSchema(schema))
 if (Meteor.isServer) {
   widgets.remove({});
   widgets.insert({});
@@ -18,7 +21,7 @@ if (Meteor.isServer) {
   Meteor.subscribe('widgets');
 }
 
-describe('StubCollections', function () {
+describe.only('StubCollections', function () {
   it('should stub added/registered collections', function () {
     expect(widgets.find().count()).to.equal(1);
 
@@ -46,6 +49,14 @@ describe('StubCollections', function () {
 
     StubCollections.restore();
     expect(widgets.find().count()).to.equal(1);
+  });
+
+  it.only('should stub the schema of a collection', function () {
+    expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
+    StubCollections.stub([widgets]);
+    expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
+    StubCollections.restore();
+    expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
   });
 });
 


### PR DESCRIPTION
Addresses https://github.com/hwillson/meteor-stub-collections/issues/8

These changes omit the stubbing of a collection's schema if using `aldeed:collection2` package. There is a new test to verify.

![image](https://cloud.githubusercontent.com/assets/6342149/19054524/5dcbd94c-8985-11e6-8bcd-95c56ae6dae5.png)

![image](https://cloud.githubusercontent.com/assets/6342149/19054543/6ee22e34-8985-11e6-9035-dd126bc140de.png)
