### PR TITLE
Retrieve all property names of Collection, fixes #11

### DIFF
--- a/stub_collections.js
+++ b/stub_collections.js
@@ -39,7 +39,9 @@ const StubCollections = (() => {
   privateApi.sandbox = sinon.sandbox.create();
   privateApi.pairs = {};
   privateApi.collections = [];
-  privateApi.symbols = _.keys(Mongo.Collection.prototype);
+  privateApi.symbols = [];
+  for (let symbol in Mongo.Collection.prototype)
+    privateApi.symbols.push(symbol);
 
   privateApi.stubPair = (pair) => {
     privateApi.symbols.forEach((symbol) => {


### PR DESCRIPTION
Instead `_.keys` can be used `_.allKeys`, but it's not available in
Underscore.js 1.5.2.