### PR TITLE
Allow single collections with add()

### DIFF
--- a/stub_collections.js
+++ b/stub_collections.js
@@ -9,7 +9,7 @@ const StubCollections = (() => {
   /* Public API */
 
   publicApi.add = (collections) => {
-    privateApi.collections.push(...collections);
+    privateApi.collections = privateApi.collections.concat(collections);
   };
 
   publicApi.stub = (collections) => {


### PR DESCRIPTION
Using concat allows the public add() method to take arrays of collections or a single collection object, which makes the API more consistent as stub() works this way too.

If this PR makes sense, I could add a few lines to the README to explain the allowed types.