### PR TITLE
Add more stubs for Meteor CollectionHooks cols

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ See this packages [tests](https://github.com/hwillson/meteor-stub-collections/bl
 
 This project was originally created by MDG, and shipped with the [Meteor Guide's](http://guide.meteor.com) [todos](https://github.com/meteor/todos) reference application (thanks MDG!). If you have any questions/comments, open an issue [here](https://github.com/hwillson/meteor-stub-collections/issues).
 
+### 1.0.4
+
+- Fixes [issue #11](https://github.com/hwillson/meteor-stub-collections/issues/11) (again) where [CollectionHooks](https://github.com/matb33/meteor-collection-hooks/) Collections `direct` accessors were not properly stubbed (thanks [zeroasterisk](https://github.com/zeroasterisk)!).
+
 ### 1.0.3
 
 - Fixes [issue #11](https://github.com/hwillson/meteor-stub-collections/issues/11) where some inherited Collection properties were not properly stubbed (thanks [@Davidyuk](https://github.com/Davidyuk)!).

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 
 Package.describe({
   name: 'hwillson:stub-collections',
-  version: '1.0.3',
+  version: '1.0.4',
   summary: 'Stub out Meteor collections with in-memory local collections.',
   documentation: 'README.md',
   git: 'https://github.com/hwillson/meteor-stub-collections.git',


### PR DESCRIPTION
CollectionHooks builds Collections with a hijacked constructor.

They "take over" most collection methods,
but StubCollections will stub them... no problem (before this commit).

Though Collectionhooks would make a `direct` object and allow access to
the "pre-hooked" (normal) methods for the Collection.

Until this commit, that meant that all "Stubbed" collections
worked as a "stub" for normal methods like `MyCol.update()`,
but would use their "non-stubbed/real" methods when used like
`MyCol.direct.update()`

Now we are "stubbing" both set's of methods.

TODO: It would be really nice if we could make Collectionhooks still run
it's functionality on the stubbed collection :/ -- I have not been able
to figure out how to accomplish this yet.

re #11 (again)