### PR TITLE
Fix #14 - Using stubbed collections for publication tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { Mongo } from 'meteor/mongo';
+import { Random } from 'meteor/random';
 import sinon from 'sinon';
 
 const StubCollections = (() => {
@@ -16,9 +17,11 @@ const StubCollections = (() => {
     [].concat(pendingCollections).forEach((collection) => {
       if (!privateApi.pairs[collection._name]) {
         const options = {
+          connection: null,
           transform: collection._transform,
         };
-        const localCollection = new collection.constructor(null, options);
+        const stubName = collection._name + 'Stub' + Random.id();
+        const localCollection = new collection.constructor(stubName, options);
         const pair = { localCollection, collection };
         privateApi.stubPair(pair);
         privateApi.pairs[collection._name] = pair;

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 
 Package.describe({
   name: 'hwillson:stub-collections',
-  version: '1.0.6',
+  version: '1.0.7',
   summary: 'Stub out Meteor collections with in-memory local collections.',
   documentation: 'README.md',
   git: 'https://github.com/hwillson/meteor-stub-collections.git',


### PR DESCRIPTION
I tried and failed to reproduces the issue in a new project. It is probably something specific about the packages in use or the order in which dependencies are resolved.

Instead I tried a simple fix that passes through the name to the collection constructor and instead sets `connection: null` in the options object. This failed the package tests because using the same name for subsequent tests meant the changes are persisted between stubs.

The solution then was to postfix the name with a random string. This now passes the package tests and my app's tests.

-----
Using a stub-collection with johanbrook:meteor-publication-collector
sometimes causes the error

> Error: Can't publish a cursor from a collection without a name.

The simple fix for this is to create a localCollection with a name. To
ensure that the stubbed collection doesn't connect to an existing local
collection that was stubbed previously, we randomise the name.