### PR TITLE
Properly fix #14 and fix #24

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -65,9 +65,10 @@ describe('StubCollections', function () {
   it("should stub mutliple null collections", function() {
     localWidgets1.insert({});
     localWidgets2.insert({});
+    localWidgets2.insert({});
 
     expect(localWidgets1.find().count()).to.equal(1);
-    expect(localWidgets2.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(2);
 
     StubCollections.stub([localWidgets1, localWidgets2]);
 
@@ -77,22 +78,27 @@ describe('StubCollections', function () {
     localWidgets1.insert({});
     localWidgets1.insert({});
     localWidgets2.insert({});
-    localWidgets2.insert({});
     
     expect(localWidgets1.find().count()).to.equal(2);
-    expect(localWidgets2.find().count()).to.equal(2);
+    expect(localWidgets2.find().count()).to.equal(1);
     
     StubCollections.restore();
 
     expect(localWidgets1.find().count()).to.equal(1);
-    expect(localWidgets2.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(2);
 
     StubCollections.stub([localWidgets1, localWidgets2]);
 
     localWidgets1.insert({});
     localWidgets2.insert({});
+    localWidgets2.insert({});
 
     expect(localWidgets1.find().count()).to.equal(1);
-    expect(localWidgets2.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(2);
+
+    StubCollections.restore();
+    
+    expect(localWidgets1.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(2);
   });
 });

--- a/tests.js
+++ b/tests.js
@@ -9,6 +9,9 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import StubCollections from './index';
 
 const widgets = new Mongo.Collection('widgets');
+const localWidgets1 = new Mongo.Collection(null);
+const localWidgets2 = new Mongo.Collection(null);
+
 const schema = { schemaKey: { type: String, optional: true } };
 widgets.attachSchema(new SimpleSchema(schema));
 if (Meteor.isServer) {
@@ -57,5 +60,39 @@ describe('StubCollections', function () {
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
     StubCollections.restore();
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
+  });
+  
+  it("should stub mutliple null collections", function() {
+    localWidgets1.insert({});
+    localWidgets2.insert({});
+
+    expect(localWidgets1.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(1);
+
+    StubCollections.stub([localWidgets1, localWidgets2]);
+
+    expect(localWidgets1.find().count()).to.equal(0);
+    expect(localWidgets2.find().count()).to.equal(0);
+
+    localWidgets1.insert({});
+    localWidgets1.insert({});
+    localWidgets2.insert({});
+    localWidgets2.insert({});
+    
+    expect(localWidgets1.find().count()).to.equal(2);
+    expect(localWidgets2.find().count()).to.equal(2);
+    
+    StubCollections.restore();
+
+    expect(localWidgets1.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(1);
+
+    StubCollections.stub([localWidgets1, localWidgets2]);
+
+    localWidgets1.insert({});
+    localWidgets2.insert({});
+
+    expect(localWidgets1.find().count()).to.equal(1);
+    expect(localWidgets2.find().count()).to.equal(1);
   });
 });


### PR DESCRIPTION
The previous fix for #14 (PR #27) had an issue where it could break tests that weren't affected by #14 before because the collections object returned from `PublicationCollector` will have the randomised names, where previously folks could just reference the original collection's name like so:
```
collector.collect('projects', collections => {
    assert.equal(collections.projects.length, 3);
    done();
});
```

Using the original collection name creates the issue that `LocalCollectionDriver` caches the contents of named collections. This PR pre-emptively removes the documents from the local collection when calling `restore`, so future stubbed collections won't have the old docs.

To handle the case where multiple null/unnamed collections  are stubbed, this PR uses a `Map` to pair collections with their local collection stubs, solving #24.
