### PR TITLE
[Proposal] Add StubCollections.reset to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ import StubCollections from 'meteor/hwillson:stub-collections';
 - `StubCollections.add([collection1, collection2, ...])` - register the default list of collections to stub.
 - `StubCollections.stub()` - stub all collections that have been previously enabled for stubbing via `add()`.
 - `StubCollections.stub([collection1, collection2, ...])` - stub a specific list of collections, overriding the list registered via `add()`.
+- `StubCollections.reset()` - remove all documents from stubbed collections (e.g. call at the end of each test)
 - `StubCollections.restore()` - undo stubbing (call at the end of tests, on routing away, etc.)
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -27,13 +27,17 @@ const StubCollections = (() => {
     });
   };
 
+  publicApi.reset = () => {
+    for (const localCollection of privateApi.pairs.values()) {
+      localCollection.remove({});
+    }
+  };
+
   publicApi.restore = () => {
     // Pre-emptively remove the documents from the local collection because if
     // a collection with the same name is stubbed later it will still have the
     // documents from LocalConnectionDriver's internal cache.
-    for (const localCollection of privateApi.pairs.values()) {
-      localCollection.remove({});
-    }
+    publicApi.reset();
     privateApi.sandbox.restore();
     privateApi.pairs.clear();
   };


### PR DESCRIPTION
Removes all documents from stubbed collections, which is useful
when running multiple tests with different documents.

I've frequently found myself needing to reset the documents in a collection beforeEach test when testing different documents in different scenarios. Currently, the only way to do this is to restore, re-add and re-stub before every test, which seems like an antipattern.

Happy to get feedback, comments, or suggestions :)