### PR TITLE
feature: add collection2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ import StubCollections from 'meteor/hwillson:stub-collections';
 
 See this packages [tests](https://github.com/hwillson/meteor-stub-collections/blob/3a0ac26121d8e864cd5b78959b0edb7b9532c761/stub_collections.tests.js).
 
+## Testing
+
+Run the tests for this package using
+
+```bash
+$ meteor test-packages ./ --driver-package=meteortesting:mocha
+```
+
 ## History
 
 This project was originally created by MDG, and shipped with the [Meteor Guide's](http://guide.meteor.com) [todos](https://github.com/meteor/todos) reference application (thanks MDG!). If you have any questions/comments, open an issue [here](https://github.com/hwillson/meteor-stub-collections/issues).

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import { Mongo } from 'meteor/mongo';
-import { Random } from 'meteor/random';
 import sinon from 'sinon';
 
 const StubCollections = (() => {
@@ -21,6 +20,13 @@ const StubCollections = (() => {
           transform: collection._transform,
         };
         const localCollection = new collection.constructor(collection._name, options);
+
+        // compat with aldeed:collection2
+        if (collection.attachSchema && collection._c2 && Array.isArray(collection._c2._simpleSchemas)) {
+          console.debug(collection._name, 'attach schema')
+          collection._c2._simpleSchemas.forEach(entry => localCollection.attachSchema(entry.schema));
+        }
+
         privateApi.stubPair({ localCollection, collection });
         privateApi.pairs.set(collection, localCollection);
       }

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 
 Package.describe({
   name: 'hwillson:stub-collections',
-  version: '1.0.9',
+  version: '1.1.0',
   summary: 'Stub out Meteor collections with in-memory local collections.',
   documentation: 'README.md',
   git: 'https://github.com/hwillson/meteor-stub-collections.git',
@@ -13,6 +13,7 @@ Package.describe({
 Npm.depends({
   chai: '4.1.2',
   sinon: '6.0.1',
+  'simpl-schema': '1.12.2'
 });
 
 Package.onUse(function onUse(api) {
@@ -27,12 +28,11 @@ Package.onUse(function onUse(api) {
 Package.onTest(function onTest(api) {
   api.use([
     'hwillson:stub-collections',
-    'aldeed:simple-schema@1.5.3',
-    'aldeed:collection2@2.10.0',
+    'aldeed:collection2@3.5.0',
     'ecmascript',
     'mongo',
     'lmieulet:meteor-coverage@2.0.2', // Needed until https://github.com/meteortesting/meteor-mocha/pull/69 is merged
-    'meteortesting:mocha@1.0.0',
+    'meteortesting:mocha@2.0.0',
   ]);
   api.mainModule('tests.js');
 });

--- a/tests.js
+++ b/tests.js
@@ -4,8 +4,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { expect } from 'chai';
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-
+import SimpleSchema from 'simpl-schema';
 import StubCollections from './index';
 
 const widgets = new Mongo.Collection('widgets');
@@ -13,7 +12,19 @@ const localWidgets1 = new Mongo.Collection(null);
 const localWidgets2 = new Mongo.Collection(null);
 
 const schema = { schemaKey: { type: String, optional: true } };
-widgets.attachSchema(new SimpleSchema(schema));
+const options = {
+  clean: {
+    autoConvert: false,
+    filter: false,
+    getAutoValues: false,
+    removeEmptyStrings: false,
+    removeNullsFromArrays: false,
+    trimStrings: false
+  },
+  humanizeAutoLabels: false,
+  requiredByDefault: true
+};
+widgets.attachSchema(new SimpleSchema(schema, options));
 if (Meteor.isServer) {
   widgets.remove({});
   widgets.insert({});
@@ -60,6 +71,13 @@ describe('StubCollections', function () {
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
     StubCollections.restore();
     expect(widgets.simpleSchema()._firstLevelSchemaKeys).to.include('schemaKey');
+  });
+
+  it('should be compatible with collection2', function () {
+    StubCollections.stub([widgets]);
+    expect(() => widgets.insert({ foo: 'bar' }))
+      .to.throw('foo is not allowed by the schema in widgets insert');
+    StubCollections.restore();
   });
   
   it("should stub mutliple null collections", function() {


### PR DESCRIPTION
This implements compatibility for collection2, as mentioned in #12 

How it works:

It checks via duckt-yping, whether the original collection contains `attachSchema` and `_c2` and subsequently iterates all attached schemas and attaches them to the new local collection.

Tests were added as well but I had to update some versions in order to make this work.

Also added a hint how to test this package.